### PR TITLE
Add a rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
I normally have rustup set to use the latest stable release, so having this was helpful for me to give rustup a hint that it should switch to nightly for this project.